### PR TITLE
feat: add binaries to releases and support freebsd builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,4 @@
 # Make sure to check the documentation at https://goreleaser.com
-
 version: 2
 
 before:
@@ -9,8 +8,11 @@ before:
 builds:
   - env:
       - CGO_ENABLED=0
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    binary: terrafetch
     goos:
       - linux
+      - freebsd
       - windows
       - darwin
 
@@ -39,6 +41,8 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
+  - format: binary
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
     format_overrides:
       - goos: windows
         format: zip


### PR DESCRIPTION
## Why

This pull request updates the `.goreleaser.yaml` configuration file to improve binary builds and packaging. The changes include adding support for FreeBSD, specifying a custom binary name template, and introducing a new binary format in archives.

**Build configuration updates:**
* Added `mod_timestamp` using the commit timestamp and specified `binary` as `terrafetch` for builds. Also added support for FreeBSD in the `goos` list. (`[.goreleaser.yamlR11-R15](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826R11-R15)`)

**Archive configuration updates:**
* Introduced a new `binary` format and defined a custom `name_template` for archive naming, improving clarity and consistency in output files. (`[.goreleaser.yamlR44-R45](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826R44-R45)`)
