### PR TITLE
fix: refactor goreleaser deprecations, support binary builds, and support freebsd

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,8 +8,6 @@ before:
 builds:
   - env:
       - CGO_ENABLED=0
-    mod_timestamp: '{{ .CommitTimestamp }}'
-    binary: terrafetch
     goos:
       - linux
       - freebsd
@@ -33,7 +31,9 @@ nfpms:
     license: Apache 2.0
 
 archives:
-  - format: tar.gz
+  - id: tar
+    formats:
+      - tar.gz
     name_template: >-
       {{ .ProjectName }}_
       {{- title .Os }}_
@@ -41,11 +41,13 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
-  - format: binary
+  - id: binary
+    formats:
+      - binary
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 changelog:
   sort: asc


### PR DESCRIPTION
## Why

This pull request updates the `.goreleaser.yaml` configuration file to simplify and enhance the build and packaging process. The most important changes include removing unused fields, restructuring archive format definitions, and improving clarity in format overrides.

### Build process updates:
* Removed the `mod_timestamp` and `binary` fields from the `builds` section, as they are no longer required. (`[.goreleaser.yamlL11-L12](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L11-L12)`)

### Packaging improvements:
* Restructured the `archives` section to use `id` and `formats` for better organization and flexibility. This replaces the previous single `format` field with a more detailed structure. (`[.goreleaser.yamlL36-R50](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L36-R50)`)
* Updated the `format_overrides` in the `archives` section to use an array (`formats: [zip]`) for consistency and clarity. (`[.goreleaser.yamlL36-R50](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L36-R50)`)
